### PR TITLE
Fix psycopg2 lib version

### DIFF
--- a/djangodocker/settings.py
+++ b/djangodocker/settings.py
@@ -78,10 +78,10 @@ WSGI_APPLICATION = 'djangodocker.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'djangotodo',
-        'USER': 'djangotodo',
+        'NAME': 'postgres',
+        'USER': 'postgres',
         'PASSWORD': 'hunter2',
-        'HOST': 'localhost'
+        'HOST': 'db'
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django==1.11.3
 pytz==2017.2
-psycopg2==2.7.1
+psycopg2==2.8.4


### PR DESCRIPTION
Hi,
psycopg2 library have some issues and is causing crush during docker container stand up.
I changed version of psycopg2 to newest (2.8.4) and it helped.