### PR TITLE
upgrade PostgreSQL and fix UTC Error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
      - db
 
   db:
-    image: "postgres:9.6"
+    image: "postgres:12"
     ports:
       - "5432:5432"
     environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django==1.11.3
 pytz==2017.2
-psycopg2==2.7.1
+psycopg2==2.8.6


### PR DESCRIPTION
Use a more recent PostgreSQL version and fix the UTC error in latest psycopg2 versions (see https://stackoverflow.com/questions/68024060/assertionerror-database-connection-isnt-set-to-utc)